### PR TITLE
ticket type free validation

### DIFF
--- a/bundesliga_app/forms.py
+++ b/bundesliga_app/forms.py
@@ -59,6 +59,17 @@ class DiscountForm(forms.Form):
                 _('You cant create a discount in a free event'),
             )
             return False
+        valid_free_ticket = get_ticket_type(
+            self.user,
+            self.event.event_id,
+            self.ticket_type_id,
+        )[self.ticket_type_id]['free']
+        if valid_free_ticket:
+            self.add_error(
+                '__all__',
+                _('You cant create a discount for a free ticket'),
+            )
+            return False
         if not self.discount_id:
             discount = Discount.objects.filter(
                 ticket_type=self.ticket_type_id

--- a/bundesliga_app/models.py
+++ b/bundesliga_app/models.py
@@ -26,9 +26,6 @@ class Discount(models.Model):
     value = models.IntegerField()
     value_type = models.CharField(max_length=200)
 
-    def __str__(self):
-        return self.name
-
 
 class DiscountCode(models.Model):
     member_number = models.CharField(max_length=200)

--- a/bundesliga_app/utils.py
+++ b/bundesliga_app/utils.py
@@ -111,7 +111,6 @@ def get_event_tickets_eb_api(token, event_id):
     This method will receive a event id and token from logged user
     and returns a list of tickets
     """
-
     eventbrite = Eventbrite(token)
     return [
         ticket

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,7 @@
 						<div class="eds-g-cell eds-g-cell-lw-2-12 eds-g-cell-lg-2-12 eds-g-cell-ln-2-12 eds-g-cell-mw-2-12 eds-g-cell-md-2-12 eds-g-cell-mn-2-12 eds-g-cell-4-12">
 							<p class="eds-text-bm--fixed eds-text-color--grey-700 eds-text--right">{% trans "FREE EVENT" %}</p>
 						</div>
-			{% elif event.discount %}
+			{% elif event.has_discount %}
 			<div class="eds-ticket-card-content eds-ticket-edit-card-content" style="background-color: #FFFFFF" onclick="location.href='{% url 'events_discount' id %}';">
 				<div class="eds-g-cell eds-g-cell-1-1 eds-ticket-card-content__details-wrapper">
 					<div class="eds-g-cell eds-g-cell-1-1 eds-ticket-card-content__details">
@@ -75,9 +75,6 @@
 									{% trans "Discount created" %}
 								</p>
 							</div>
-						</div>
-						<div class="eds-g-cell eds-g-cell-lw-2-12 eds-g-cell-lg-2-12 eds-g-cell-ln-2-12 eds-g-cell-mw-2-12 eds-g-cell-md-2-12 eds-g-cell-mn-2-12 eds-g-cell-4-12">
-							<p class="eds-text-bm--fixed eds-text-color--grey-700 eds-text--right">- {{ event.discount }} %</p>
 						</div>
 			{% else %}
 			<div class="eds-ticket-card-content eds-ticket-edit-card-content" style="background-color: #FFFFFF" onclick="location.href='{% url 'events_discount' id %}';">
@@ -98,8 +95,7 @@
 				</div>
 				<div class="eds-g-cell eds-g-cell-1-12 eds-g-cell--has-overflow">
 					{% if not event.is_free %}
-						{% if event.discount %}
-						<div class="eds-text--right">
+						{% if event.has_discount %}
 							<div class="eds-more-actions">
 								<span class="eds-icon-button eds-icon-button--dark">
 									<a href="{% url 'events_discount' id %}">
@@ -107,7 +103,6 @@
 									</a>
 								</span>
 							</div>
-						</div>
 						{% else %}
 						<div class="eds-more-actions">
 							<span class="eds-icon-button eds-icon-button--dark">

--- a/templates/organizer/create_discount.html
+++ b/templates/organizer/create_discount.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 <body>
 <div class="mt-5 row">
-    <p><a href="{% url 'index' %}">{% trans "Home" %}</a>&nbsp;&nbsp;>&nbsp;&nbsp;<a href="{% url 'events_discount' event.id %}">{% trans "Event Discounts" %}</a>&nbsp;&nbsp;>&nbsp;&nbsp;{% trans "Manage discounts" %}</p>
+    <p><a href="{% url 'index' %}">{% trans "Home" %}</a>&nbsp;&nbsp;>&nbsp;&nbsp;<a href="{% url 'events_discount' event.id %}">{% trans "Event tickets type" %}</a>&nbsp;&nbsp;>&nbsp;&nbsp;{% trans "Manage discounts" %}</p>
 </div>
 	<div class="container">
 		<div class="mt-5">

--- a/templates/organizer/event_discounts.html
+++ b/templates/organizer/event_discounts.html
@@ -3,10 +3,10 @@
 {% load i18n %}
 {% block content %}
 <div class="mt-5 row">
-    <p><a href="{% url 'index' %}"> {% trans "Home" %} </a>&nbsp;&nbsp;>&nbsp;&nbsp;{% trans "Event discounts" %}</p>
+    <p><a href="{% url 'index' %}"> {% trans "Home" %} </a>&nbsp;&nbsp;>&nbsp;&nbsp;{% trans "Event tickets type" %}</p>
 </div>
 <div>
-	<h1 class="mt-2">{{event_name}}{% trans "'s Discounts" %}</h1>
+	<h1 class="mt-2">{{event_name}}{% trans "'s Tickets Type" %}</h1>
 	<hr>
 </div>
 
@@ -23,11 +23,16 @@
 						</svg>
 					</i>
 				</span>
-				{% if ticket_type.discount %}
+				{% if ticket_type.free %}
+				<div class="eds-l-pad-hor-4 eds-g-cell eds-g-cell-8-12">
+					<h5>{{ticket_type.name}}</h5>
+					<p class="eds-text-bm--fixed eds-text-color--grey-700 "> <span class="eds-show-up-mn eds-ticket-card-status-icon eds-text-color--ui-red eds-l-mar-right-2"></span> {% trans "Free Ticket Type" %}</p>
+				</div>
+				{% elif ticket_type.discount %}
 				<div class="eds-l-pad-hor-4 eds-g-cell eds-g-cell-8-12">
 					<h5>{{ticket_type.name}}</h5>
 					<p class="eds-text-bm--fixed eds-text-color--grey-700 "> {{ticket_type.discount.name}} </p>
-					<p class="eds-text-bm--fixed eds-text-color--grey-700 ">  {{ticket_type.discount.value}} {% trans "% off" %}</p>
+					<p class="eds-text-bm--fixed eds-text-color--grey-700 "> <span class="eds-show-up-mn eds-ticket-card-status-icon eds-text-color--ui-green eds-l-mar-right-2"></span>  {{ticket_type.discount.value}} {% trans "% off" %}</p>
 				</div>
 				<div class="modal" id="modal">
 
@@ -56,6 +61,7 @@
 				{% else %}
 				<div class="eds-l-pad-hor-4 eds-g-cell eds-g-cell-8-12">
 					<h5>{{ticket_type.name}}</h5>
+					<p class="eds-text-bm--fixed eds-text-color--grey-700 "> <span class="eds-show-up-mn eds-ticket-card-status-icon eds-text-color--tropical-yellow-400 eds-l-mar-right-2"></span>  {% trans "No discount yet" %}</p>
 				</div>
 				<div class="eds-g-cell eds-g-cell-3-12 eds-g-cell-mn-2-12 eds-g-cell--has-overflow">
 					<p>


### PR DESCRIPTION
- Not allow to create a discount for a free ticket type

- Refactor events discounts view. Now it updates the tickets types from EB (if its free, if it was deleted, or its a new ticket type)

- Front end template index and event discount fixed. Now we can visualize if it has a discount or not